### PR TITLE
Run boot twice to cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ ENV BOOT_LOCAL_REPO /m2
 ENV BOOT_JVM_OPTIONS=-Xmx2g
 
 # download & install deps, cache REPL and web deps
-RUN /usr/bin/boot web -s doesnt/exist repl -e '(System/exit 0)' && rm -rf target
+RUN /usr/bin/boot && /usr/bin/boot web -s doesnt/exist repl -e '(System/exit 0)' && rm -rf target
 
 ENTRYPOINT ["/usr/bin/boot"]


### PR DESCRIPTION
Not sure if/when this changed, but running `boot` the first time on a new system grabs the necessary `boot` binaries, but then ignores subsequent commands. So in order to actually cache REPL and web deps as the comment here indicates, `boot` should be run twice: once to download `boot` proper, and once to actually run the tasks and cache deps.