### PR TITLE
Update to the most recent Java 8 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && cd /tmp \
     && wget -qO jdk8.tar.gz \
        --header "Cookie: oraclelicense=accept-securebackup-cookie" \
-       http://download.oracle.com/otn-pub/java/jdk/8u25-b17/jdk-8u25-linux-x64.tar.gz \
+       http://download.oracle.com/otn-pub/java/jdk/8u112-b15/jdk-8u112-linux-x64.tar.gz \
     && tar xzf jdk8.tar.gz -C /opt \
     && mv /opt/jdk* /opt/java \
     && rm /tmp/jdk8.tar.gz \


### PR DESCRIPTION
This just changes the download URL so the most recent Java 8 release is used (JDK8u112)